### PR TITLE
Update Singleton.cs

### DIFF
--- a/Scripts/Utils/Singleton.cs
+++ b/Scripts/Utils/Singleton.cs
@@ -60,7 +60,7 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
         }
 
         _instance = (this as T);
-        DontDestroyOnLoad(gameObject);
+        //DontDestroyOnLoad(gameObject);
         SceneManager.sceneUnloaded += SceneUnload;
     }
 
@@ -76,6 +76,6 @@ public class Singleton<T> : MonoBehaviour where T : MonoBehaviour
 
     protected virtual void SceneUnload( Scene scene )
     {
-        DestroyImmediate(gameObject);
+        //DestroyImmediate(gameObject);
     }
 }


### PR DESCRIPTION
Na Unity 2017 o sceneUnloaded é chamado em momentos estranhos (como inspecionando objeto que possui Material durante Play Mode). Para contornar isso, comentei as linhas com DontDestroyOnLoad e DestroyImmediate. A propósito, a existência dos dois não é contrária? Ou seja, DestroyImmediate acaba com o que o DontDestroyOnLoad estava fazendo